### PR TITLE
Explicitly track JS dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ It borrows both Yacin's package above and the ZeekJS reimplementation of _that_ 
 [zeekjs-notice-slack](https://github.com/pgaulon/zeekjs-notice-slack/).
 
 ## Code generation
-Re-generating `scripts/telegram.js` from the TypeScript source can be done by running `make` in the `scripts` directory. This requires:
-- `make` and the `tsc` transpiler
-- The nodejs type definitions (use `npm install --save @types/node`)
+
+Re-generating `scripts/telegram.js` from the TypeScript source can be done by
+running `npm install && npm run build`.
 
 ## Example usage
 Basic usage is identical to [zeek-notice-telegram](https://github.com/corelight/zeek-notice-telegram). To recap, one might use it like this:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,32 @@
+{
+  "name": "zeekjs-notice-telegram",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@types/node": "^20.6.0",
+        "typescript": "^5.2.2"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.0.tgz",
+      "integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg==",
+      "dev": true
+    },
+    "node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "type": "module",
+  "devDependencies": {
+    "@types/node": "^20.6.0",
+    "typescript": "^5.2.2"
+  },
+  "scripts": {
+    "build": "cd scripts && tsc -p ."
+  }
+}

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -1,2 +1,0 @@
-telegram.js: telegram.ts zeek.d.ts zeektypes.d.ts
-	tsc -p .

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,1 +1,0 @@
-{"type":"module","devDependencies":{"@types/node":"^20.4.6"}}


### PR DESCRIPTION
This adds explicit tracking of JS dependencies used to transpile the TS code in the repo for reproducibility. While at it, I also simplified the way we generate the JS code by moving `package.json` from `scripts/` into the root folder. This allows us to use npm to generate the code instead of having introduce an additional dependency on `make`.